### PR TITLE
fix: replace Lambda Handler Function format to remove the @ts-ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "name": "remote-patient-monitoring",
   "devDependencies": {
     "@shelf/jest-dynamodb": "^1.7.0",
+    "@types/aws-lambda": "^8.10.70",
     "@types/jest": "^26.0.20",
     "@types/swagger-ui-dist": "^3.30.0",
     "@types/uuid": "^8.3.0",
-    "aws-lambda": "^1.0.6",
     "axios": "^0.21.1",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.1",

--- a/src/lambda/admin.ts
+++ b/src/lambda/admin.ts
@@ -1,11 +1,10 @@
 "use strict";
+import { APIGatewayProxyHandler } from 'aws-lambda'
 import { CognitoAdmin } from '../aws/cognito_admin'
-
 import Validator from "../util/validator";
 
 export namespace Admin {
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function postAdminLogin(event: any, context: any, callback: Function) {
+  export const postAdminLogin: APIGatewayProxyHandler = async (event) => {
     try {
       console.log(event)
       const validator = new Validator();
@@ -13,18 +12,18 @@ export namespace Admin {
 
       const admin = new CognitoAdmin()
       const res = await admin.signIn(bodyData.username, bodyData.password);
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify({ username: bodyData.username, idToken: res?.AuthenticationResult?.IdToken! }),
-      });
+      };
     } catch (err) {
       console.log("putAdminLogin error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 }

--- a/src/lambda/center.ts
+++ b/src/lambda/center.ts
@@ -1,5 +1,6 @@
 "use strict";
 import AWS from "aws-sdk";
+import { APIGatewayProxyHandler } from 'aws-lambda'
 var dynamodb = require('serverless-dynamodb-client');
 
 AWS.config.update({
@@ -10,8 +11,7 @@ import CenterTable from "../aws/centerTable";
 import Validator from "../util/validator";
 
 export namespace Center {
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getCenters(event: any, context: any, callback: Function) {
+  export const getCenters: APIGatewayProxyHandler = async () => {
     const centerTable = new CenterTable(docClient);
     const validator = new Validator();
     try {
@@ -21,30 +21,29 @@ export namespace Center {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("getCenterTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function postCenter(event: any, context: any, callback: Function) {
+  export const postCenter: APIGatewayProxyHandler = async (event) => {
     console.log('called postCenter');
     const centerTable = new CenterTable(docClient);
     const validator = new Validator();
@@ -56,33 +55,41 @@ export namespace Center {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       const res = await centerTable.postCenter(bodyData);
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("postCenterTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getCenter(event: any, context: any, callback: Function) {
+  export const getCenter: APIGatewayProxyHandler = async (event) => {
     const centerTable = new CenterTable(docClient);
     const validator = new Validator();
+    if (!event.pathParameters || !event.pathParameters.centerId) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({
+          errorCode: "RPM00001",
+          errorMessage: 'Not Found'
+        })
+      }
+    }
     console.log('call getCenter with ' + event.pathParameters.centerId);
     try {
       const res = await centerTable.getCenter(event.pathParameters.centerId);
@@ -92,32 +99,31 @@ export namespace Center {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       console.log(res);
       console.log(JSON.stringify(res));
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify((res as AWS.DynamoDB.GetItemOutput).Item),
-      });
+      };
     } catch (err) {
       console.log("getCenterTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function putCenter(event: any, context: any, callback: Function) {
+  export const putCenter: APIGatewayProxyHandler = async (event) => {
     const centerTable = new CenterTable(docClient);
     const validator = new Validator();
     const bodyData = validator.jsonBody(event.body);
@@ -127,29 +133,38 @@ export namespace Center {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
+      }
+      if (!event.pathParameters || !event.pathParameters.centerId) {
+        return {
+          statusCode: 404,
+          body: JSON.stringify({
+            errorCode: "RPM00001",
+            errorMessage: 'Not Found'
+          })
+        }
       }
       const res = await centerTable.putCenter(
         event.pathParameters.centerId,
         bodyData
       );
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("putCenterTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 }

--- a/src/lambda/nurse.ts
+++ b/src/lambda/nurse.ts
@@ -1,5 +1,6 @@
 "use strict";
 import AWS from "aws-sdk";
+import { APIGatewayProxyHandler } from 'aws-lambda'
 var dynamodb = require('serverless-dynamodb-client');
 var docClient = dynamodb.doc;
 
@@ -11,8 +12,7 @@ import Validator from "../util/validator";
 
 export namespace Nurse {
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getNurses(event: any, context: any, callback: Function) {
+  export const getNurses: APIGatewayProxyHandler = async () => {
     const nurseTable = new NurseTable(docClient);
     const validator = new Validator();
     try {
@@ -22,30 +22,29 @@ export namespace Nurse {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("getNurseTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function postNurse(event: any, context: any, callback: Function) {
+  export const postNurse: APIGatewayProxyHandler = async (event) => {
     console.log('called postNurse');
     const nurseTable = new NurseTable(docClient);
     const validator = new Validator();
@@ -56,33 +55,41 @@ export namespace Nurse {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       const res = await nurseTable.postNurse(bodyData);
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("postNurseTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getNurse(event: any, context: any, callback: Function) {
+  export const getNurse: APIGatewayProxyHandler = async (event) => {
     const nurseTable = new NurseTable(docClient);
     const validator = new Validator();
+    if (!event.pathParameters || !event.pathParameters.nurseId) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({
+          errorCode: "RPM00001",
+          errorMessage: 'Not Found'
+        })
+      }
+    }
     console.log('call getNurse with ' + event.pathParameters.nurseId);
     try {
       const res = await nurseTable.getNurse(event.pathParameters.nurseId);
@@ -92,32 +99,31 @@ export namespace Nurse {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       console.log(res);
       console.log(JSON.stringify(res));
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("getNurseTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function putNurse(event: any, context: any, callback: Function) {
+  export const putNurse: APIGatewayProxyHandler = async (event) => {
     const nurseTable = new NurseTable(docClient);
     const validator = new Validator();
     const bodyData = validator.jsonBody(event.body);
@@ -127,29 +133,38 @@ export namespace Nurse {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
+      }
+      if (!event.pathParameters || !event.pathParameters.nurseId) {
+        return {
+          statusCode: 404,
+          body: JSON.stringify({
+            errorCode: "RPM00001",
+            errorMessage: 'Not Found'
+          })
+        }
       }
       const res = await nurseTable.putNurse(
         event.pathParameters.nurseId,
         bodyData
       );
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("putNurseTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 }

--- a/src/lambda/patient.ts
+++ b/src/lambda/patient.ts
@@ -1,4 +1,5 @@
 "use strict";
+import { APIGatewayProxyHandler } from "aws-lambda";
 import AWS from "aws-sdk";
 var dynamodb = require('serverless-dynamodb-client');
 var docClient = dynamodb.doc;
@@ -10,8 +11,7 @@ import PatientTable from "../aws/patientTable";
 import Validator from "../util/validator";
 
 export namespace Patient {
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getPatients(event: any, context: any, callback: Function) {
+  export const getPatients: APIGatewayProxyHandler = async () => {
     const patientTable = new PatientTable(docClient);
     const validator = new Validator();
     try {
@@ -21,30 +21,29 @@ export namespace Patient {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("getPatientTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function postPatient(event: any, context: any, callback: Function) {
+  export const postPatient: APIGatewayProxyHandler = async (event) => {
     console.log('called postPatient');
     const patientTable = new PatientTable(docClient);
     const validator = new Validator();
@@ -55,33 +54,41 @@ export namespace Patient {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       const res = await patientTable.postPatient(bodyData);
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("postPatientTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function getPatient(event: any, context: any, callback: Function) {
+  export const getPatient: APIGatewayProxyHandler = async (event) => {
     const patientTable = new PatientTable(docClient);
     const validator = new Validator();
+    if (!event.pathParameters || !event.pathParameters.patientId) {
+      return {
+        statusCode: 404,
+        body: JSON.stringify({
+          errorCode: "RPM00001",
+          errorMessage: 'Not Found'
+        })
+      }
+    }
     console.log('call getPatient with ' + event.pathParameters.patientId);
     try {
       const res = await patientTable.getPatient(event.pathParameters.patientId);
@@ -91,64 +98,72 @@ export namespace Patient {
           errorCode: "RPM00001",
           errorMessage: "Not Found",
         };
-        callback(null, {
+        return {
           statusCode: 404,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
       }
       console.log(res);
       console.log(JSON.stringify(res));
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("getPatientTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 
-  //@ts-ignore TS6133: 'event, context' is declared but its value is never read.
-  export async function putPatient(event: any, context: any, callback: Function) {
+  export const putPatient: APIGatewayProxyHandler = async (event) => {
     const patientTable = new PatientTable(docClient);
     const validator = new Validator();
     const bodyData = validator.jsonBody(event.body);
     try {
-      if (!validator.checkPatientBody(bodyData)) {
+      if (!event.body || !validator.checkPatientBody(bodyData)) {
         const errorModel = {
           errorCode: "RPM00002",
           errorMessage: "Invalid Body",
         };
-        callback(null, {
+        return {
           statusCode: 400,
           body: JSON.stringify({
             errorModel,
           }),
-        });
+        };
+      }
+      if (!event.pathParameters || !event.pathParameters.patientId) {
+        return {
+          statusCode: 404,
+          body: JSON.stringify({
+            errorCode: "RPM00001",
+            errorMessage: 'Not Found'
+          })
+        }
       }
       const res = await patientTable.putPatient(
         event.pathParameters.patientId,
         JSON.parse(event.body)
       );
-      callback(null, {
+      return {
         statusCode: 200,
         body: JSON.stringify(res),
-      });
+      };
     } catch (err) {
       console.log("putPatientTable-index error");
-      callback(null, {
+      return {
         statusCode: 500,
         body: JSON.stringify({
           error: err
         }),
-      });
+      };
     }
   }
 }


### PR DESCRIPTION
Lambda関数に`@ts-ignore`がついていたのが気になったので型定義の設定と戻り値の変更を加えました。

Lambda関数は非同期`async`で実装する場合、`callback`を使わずにreturnするのが一般的な使い方です。
callbackを使う場合は同期的に書くことを想定されていることが多く、型定義ファイルでも`void` or `Promise<TResult>`で定義されています。
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/handler.d.ts#L84-L88

また、eventに型を設定した関係で、`event.pathParameters`のnull checkが必要となりましたので、こちらも合わせて追加しています。