### PR TITLE
fix #84 delete status の時に、存在しないIDを送ってもエラーにならない

### DIFF
--- a/src/aws/patientTable.ts
+++ b/src/aws/patientTable.ts
@@ -173,9 +173,12 @@ export default class PatientTable {
   async deletePatientStatus(patientId: string, statusId: string) {
     try {
       const ret = await this.getPatient(patientId)
-
+      
       const patient = ret as Patient
       if (patient.statuses) {
+        if (patient.statuses.findIndex(item => item.statusId === statusId) === -1) {
+          throw new Error('no status found')
+        }
         patient.statuses.splice(patient.statuses.findIndex(item => item.statusId === statusId), 1)
       }
       const ret2 = await this.putPatient(patientId, patient)

--- a/test/e2e/fulltest.spec.ts
+++ b/test/e2e/fulltest.spec.ts
@@ -636,12 +636,21 @@ describe('Patient user', () => {
     await expect(t).rejects.toThrow(/403/);
   });
 
+  it('delete non-existing status', async () => {
+    expect.assertions(1);
+    const t = async () => {
+      const ret = await axios_patient.delete(entry_point + `/api/patient/patients/${patient_id}/statuses/undefined`);
+    }
+    await expect(t).rejects.toThrow(/500/)
+  });
+
   it('delete specified status', async () => {
     const ret = await axios_patient.delete(entry_point + `/api/patient/patients/${patient_id}/statuses/${status_id}`);
     expect(ret.status).toBe(200)
     expect(ret.data.statuses.length).toBe(2);
     expect(ret.data.statuses.findIndex((item: any) => item.status_id === status_id)).toBe(-1)
   });
+
   it('get two statuses', async () => {
     const ret = await axios_patient.get(entry_point + `/api/patient/patients/${patient_id}/statuses`);
     expect(ret.data.length).toBe(2);


### PR DESCRIPTION
status 500 を返すようにした