### PR TITLE
Add better defaults

### DIFF
--- a/serverless-lambda.yml
+++ b/serverless-lambda.yml
@@ -29,6 +29,9 @@ provider:
   region: ap-northeast-1
   apiGateway:
     shouldStartNameWithService: true
+    minimumCompressionSize: 1024
+  environment:
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
 
   # you can add statements to the Lambda function's IAM Role here
   #  iamRoleStatements:

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,9 @@ provider:
   region: ap-northeast-1
   apiGateway:
     shouldStartNameWithService: true
+    minimumCompressionSize: 1024
+  environment:
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
 
   # you can add statements to the Lambda function's IAM Role here
   #  iamRoleStatements:


### PR DESCRIPTION
minimumCompressionSize: API Gatewayのgzip compressionを有効化
AWS_NODEJS_CONNECTION_REUSE_ENABLED: TCP keep aliveの有効化
https://docs.aws.amazon.com/ja_jp/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html